### PR TITLE
support sending transactional emails via Sailthru 

### DIFF
--- a/lib/create_send_rails.rb
+++ b/lib/create_send_rails.rb
@@ -2,6 +2,7 @@ require 'action_mailer'
 require 'create_send_rails/deliverer'
 require 'create_send_rails/ext/action_mailer'
 require 'create_send_rails/ext/hash'
+require 'create_send_rails/sailthru_email_formatter'
 require 'create_send_rails/smart_email_formatter'
 
 module CreateSendRails

--- a/lib/create_send_rails/deliverer.rb
+++ b/lib/create_send_rails/deliverer.rb
@@ -10,7 +10,6 @@ module CreateSendRails
     end
 
     def deliver!(mail)
-      binding.pry
       @mail = mail
 
       delivery_system == SAILTHRU ? send_via_sailthru : send_via_createsend
@@ -21,7 +20,7 @@ module CreateSendRails
     attr_reader :mail
 
     def sailthru_auth
-      self.settings.dup
+      settings.dup
     end
 
     def send_via_createsend
@@ -55,6 +54,7 @@ module CreateSendRails
 
     def parsed_body
       return if @mail.try(:body).empty?
+
       JSON.parse(@mail.try(:body).try(:raw_source)).symbolize_keys!
     end
   end

--- a/lib/create_send_rails/deliverer.rb
+++ b/lib/create_send_rails/deliverer.rb
@@ -55,7 +55,8 @@ module CreateSendRails
     def parsed_body
       return {} unless @mail.try(:body).present?
 
-      JSON.parse(@mail.try(:body).try(:raw_source)).symbolize_keys!
+      raw_source = mail.try(:body).try(:raw_source) || mail.try(:body).try(:[], :raw_source)
+      raw_source.symbolize_keys!
     end
   end
 end

--- a/lib/create_send_rails/deliverer.rb
+++ b/lib/create_send_rails/deliverer.rb
@@ -53,7 +53,7 @@ module CreateSendRails
     end
 
     def parsed_body
-      return if @mail.try(:body).empty?
+      return {} unless @mail.try(:body).present?
 
       JSON.parse(@mail.try(:body).try(:raw_source)).symbolize_keys!
     end

--- a/lib/create_send_rails/deliverer.rb
+++ b/lib/create_send_rails/deliverer.rb
@@ -2,29 +2,60 @@ module CreateSendRails
   class Deliverer
     attr_accessor :settings
 
+    SAILTHRU = 'sailthru'.freeze
+    CREATSEND = 'creatsend'.freeze
+
     def initialize(values)
       self.settings = {}.merge(values)
     end
 
     def deliver!(mail)
+      binding.pry
       @mail = mail
 
-      smart_email = ::CreateSend::Transactional::SmartEmail.new(auth, smart_email_id)
-      smart_email.send(mail_data)
+      delivery_system == SAILTHRU ? send_via_sailthru : send_via_createsend
     end
 
     private
 
-    def auth
+    attr_reader :mail
+
+    def sailthru_auth
       self.settings.dup
     end
 
-    def mail_data
-      SmartEmailFormatter.new(@mail).format
+    def send_via_createsend
+      smart_email = ::CreateSend::Transactional::SmartEmail.new(auth, smart_email_id)
+      smart_email.send(mail_data)
+    end
+
+    def send_via_sailthru
+      sailthru_client.api_post(:send, sailthru_mail_data)
+    end
+
+    def sailthru_client
+      Sailthru::Client.new
+    end
+
+    def delivery_system
+      parsed_body[:delivery_system]
     end
 
     def smart_email_id
-      mail_data[:data][:smart_email_id]
+      parsed_body[:smart_email_id]
+    end
+
+    def sailthru_mail_data
+      SailthruEmailFormatter.new(@mail, parsed_body).format
+    end
+
+    def mail_data
+      SmartEmailFormatter.new(@mail, parsed_body).format
+    end
+
+    def parsed_body
+      return if @mail.try(:body).empty?
+      JSON.parse(@mail.try(:body).try(:raw_source)).symbolize_keys!
     end
   end
 end

--- a/lib/create_send_rails/sailthru_email_formatter.rb
+++ b/lib/create_send_rails/sailthru_email_formatter.rb
@@ -1,52 +1,51 @@
 module CreateSendRails
-    class SailthruEmailFormatter
-      RESERVED_KEYS = %i[smart_email_id sailthru_template_name delivery_system]
+  class SailthruEmailFormatter
+    RESERVED_KEYS = %i[smart_email_id sailthru_template_name delivery_system].freeze
+    def initialize(message, parsed_body)
+      @message = message
+      @parsed_body = parsed_body
+    end
 
-      def format
-        request_body.deep_reject! { |_k, v| v.blank? }
-      end
+    def format
+      request_body.deep_reject! { |_k, v| v.blank? }
+    end
 
-      private
+    private
 
-      attr_reader :message, :parsed_body
+    attr_reader :message, :parsed_body
 
-      def initialize(message, parsed_body)
-        @message = message
-        @parsed_body = parsed_body
-      end
+    def request_body
+      {
+        template: parsed_body[:sailthru_template_name],
+        email:    message.to.join(','),
+        vars:     parsed_body.except(*RESERVED_KEYS),
+        **options
+      }
+    end
 
-      def request_body
-        {
-          template: parsed_body[:sailthru_template_name],
-          email: message.to.join(','),
-          vars: parsed_body.except(*RESERVED_KEYS),
-          **options
-        }
-      end
+    def options
+      return {} if cc.empty? && bcc.empty?
 
-      def options
-        return {} if cc.empty? && bcc.empty?
-
-        {
-          options: {
-            headers: {
-              **cc,
-              **bcc
-            }
+      {
+        options: {
+          headers: {
+            **cc,
+            **bcc
           }
         }
-      end
+      }
+    end
 
-      def cc
-        return {} unless message.cc
+    def cc
+      return {} unless message.cc
 
-        { Cc: message.cc.join(',') }
-      end
+      { Cc: message.cc.join(',') }
+    end
 
-      def bcc
-        return {} unless message.bcc
+    def bcc
+      return {} unless message.bcc
 
-        { Bcc: message.bcc.join(',') }
-      end
+      { Bcc: message.bcc.join(',') }
     end
   end
+end

--- a/lib/create_send_rails/sailthru_email_formatter.rb
+++ b/lib/create_send_rails/sailthru_email_formatter.rb
@@ -1,0 +1,52 @@
+module CreateSendRails
+    class SailthruEmailFormatter
+      RESERVED_KEYS = %i[smart_email_id sailthru_template_name delivery_system]
+
+      def format
+        request_body.deep_reject! { |_k, v| v.blank? }
+      end
+
+      private
+
+      attr_reader :message, :parsed_body
+
+      def initialize(message, parsed_body)
+        @message = message
+        @parsed_body = parsed_body
+      end
+
+      def request_body
+        {
+          template: parsed_body[:sailthru_template_name],
+          email: message.to.join(','),
+          vars: parsed_body.except(*RESERVED_KEYS),
+          **options
+        }
+      end
+
+      def options
+        return {} if cc.empty? && bcc.empty?
+
+        {
+          options: {
+            headers: {
+              **cc,
+              **bcc
+            }
+          }
+        }
+      end
+
+      def cc
+        return {} unless message.cc
+
+        { Cc: message.cc.join(',') }
+      end
+
+      def bcc
+        return {} unless message.bcc
+
+        { Bcc: message.bcc.join(',') }
+      end
+    end
+  end

--- a/lib/create_send_rails/smart_email_formatter.rb
+++ b/lib/create_send_rails/smart_email_formatter.rb
@@ -1,6 +1,7 @@
 module CreateSendRails
   class SmartEmailFormatter
     def format
+      binding.pry
       request_body.deep_reject! { |_k, v| v.blank? }
     end
 

--- a/lib/create_send_rails/smart_email_formatter.rb
+++ b/lib/create_send_rails/smart_email_formatter.rb
@@ -1,7 +1,6 @@
 module CreateSendRails
   class SmartEmailFormatter
     def format
-      binding.pry
       request_body.deep_reject! { |_k, v| v.blank? }
     end
 

--- a/spec/createsend_rails/deliverer_spec.rb
+++ b/spec/createsend_rails/deliverer_spec.rb
@@ -33,12 +33,19 @@ describe CreateSendRails::Deliverer do
 
 
     context 'sailthru delivery' do
-      subject { described_class.new(request).deliver!(message) }
       let(:request) { { api: 'abcdef', delivery_system: 'sailthru' } }
-      let(:message) { double }
+      let(:message) { double ( { body: { raw_source: { delivery_system: 'sailthru' } } } ) }
 
       it 'return successfully' do
-         expect(subject).to eq(true)
+        sailthru_mock_objct = double
+        expect_any_instance_of(described_class).to receive(:sailthru_client).and_return(sailthru_mock_objct)
+        expect(sailthru_mock_objct).to receive(:api_post).and_return(true)
+        expect(message).to receive(:to).and_return(['example.email@example.com'])
+        expect(message).to receive(:cc).at_least(:once).and_return(['example_cc_email@example.com'])
+        expect(message).to receive(:bcc).at_least(:once).and_return(['example_bcc_email@example.com'])
+
+        subject = described_class.new(request).deliver!(message)
+        expect(subject).to eq(true)
       end
     end
 

--- a/spec/createsend_rails/deliverer_spec.rb
+++ b/spec/createsend_rails/deliverer_spec.rb
@@ -3,6 +3,13 @@ describe CreateSendRails::Deliverer do
     ActionMailer::Base.create_send_settings = { api_key: 'ABCDEFG' }
   end
 
+  describe 'constants' do
+    it 'validate the constants values' do
+      expect(CreateSendRails::Deliverer::SAILTHRU).to eq('sailthru')
+      expect(CreateSendRails::Deliverer::CREATSEND).to eq('creatsend')
+    end
+  end
+
   describe 'action_mailer' do
     it 'allows configuration settings' do
       expect(ActionMailer::Base.create_send_settings[:api_key]).to eq('ABCDEFG')
@@ -20,6 +27,17 @@ describe CreateSendRails::Deliverer do
       end
 
       xit 'return successfully' do
+         expect(subject).to eq(true)
+      end
+    end
+
+
+    context 'sailthru delivery' do
+      subject { described_class.new(request).deliver!(message) }
+      let(:request) { { api: 'abcdef', delivery_system: 'sailthru' } }
+      let(:message) { double }
+
+      it 'return successfully' do
          expect(subject).to eq(true)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,5 @@
-require 'codeclimate-test-reporter'
 require 'simplecov'
 SimpleCov.start
-CodeClimate::TestReporter.start
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))


### PR DESCRIPTION
Amr's description: 

This PR is adapting the creatsend gem to be able to send transactional emails via Sailthru. This is part of the work of redirecting emails to go from CS to Sailthru

Examples of the tickets involved:

Back in stock: https://onrunning.atlassian.net/browse/B2C-3468
Basket abandonment: https://onrunning.atlassian.net/browse/B2C-3674


---

# For the reviewer:

The branch that's on the main app that's using these changes: https://github.com/onrunning/on/pull/4974

Flow of testing it in the main app:

- Fetch the branch on the main app and run bundle install:

```
$ git fetch origin -a B2C-3468-pairing-session
$ git checkout B2C-3468-pairing-session
$ bundle
```

- Use the terminal to open the rails console: `bundle exec rails c`
- Fetch any backorder in your DB: `bo = Backorder.first`
- Make sure that your email is assigned to the Backorder: `bo.email = 'your_email'; bo.save!`
- Notify that the item is back in stock `BackInStockMailer.notify(bo).deliver`

Expected result: You should get a campagin email coming from Sailthru. @amrdruid can double check the logs on the Sailthru side of things.